### PR TITLE
Add OTEL_TRACES_EXPORTER note

### DIFF
--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -116,6 +116,14 @@ export default defineConfig({
 });
 ```
 
+### `Error: cannot merge resource due to conflicting Schema URL`
+
+This error can happen during the `trigger.dev deploy` process if your project initializes the OpenTelemetry SDK for tracing. Trigger.dev also sets up tracing internally, which can conflict with your configuration. Set `OTEL_TRACES_EXPORTER=none` when running the deploy command to disable your own trace exporter and resolve the conflict:
+
+```bash
+OTEL_TRACES_EXPORTER=none pnpm trigger:deploy
+```
+
 <CorepackError />
 
 


### PR DESCRIPTION
## Summary
- document how to disable OTEL trace exporter when deploying

## Testing
- `pnpm run format` *(fails: fetch to registry.npmjs.org blocked)*
- `pnpm run test` *(fails: fetch to registry.npmjs.org blocked)*

------
https://chatgpt.com/codex/tasks/task_b_685e4c63080483208ffc3928c151eefd