### PR TITLE
Enable MCP server via CLI dev flags

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "trigger.dev": {
-      "url": "http://localhost:3333/sse"
+      "url": "http://localhost:3001/sse"
     }
   }
 }

--- a/packages/cli-v3/README.md
+++ b/packages/cli-v3/README.md
@@ -35,10 +35,10 @@ To start the Trigger.dev MCP server, simply pass the `--mcp` flag to the `dev` c
 trigger dev --mcp
 ```
 
-By default it runs on port `3333`. You can change this by passing the `--mcp-port` flag:
+By default it runs on port `3001`. You can change this by passing the `--mcp-port` flag:
 
 ```bash
-trigger dev --mcp --mcp-port 3334
+trigger dev --mcp --mcp-port 3002
 ```
 
 ### Configuring your MCP client

--- a/packages/cli-v3/src/commands/dev.ts
+++ b/packages/cli-v3/src/commands/dev.ts
@@ -23,7 +23,8 @@ const DevCommandOptions = CommonCommandOptions.extend({
   keepTmpFiles: z.boolean().default(false),
   maxConcurrentRuns: z.coerce.number().optional(),
   mcp: z.boolean().default(false),
-  mcpPort: z.coerce.number().optional().default(3333),
+  // default port for the local MCP server
+  mcpPort: z.coerce.number().optional().default(3001),
   analyze: z.boolean().default(false),
   disableWarnings: z.boolean().default(false),
 });
@@ -55,7 +56,7 @@ export function configureDevCommand(program: Command) {
         "Keep temporary files after the dev session ends, helpful for debugging"
       )
       .option("--mcp", "Start the MCP server")
-      .option("--mcp-port", "The port to run the MCP server on", "3333")
+      .option("--mcp-port", "The port to run the MCP server on", "3001")
       .addOption(
         new CommandOption("--analyze", "Analyze the build output and import timings").hideHelp()
       )


### PR DESCRIPTION
## Summary
- set default MCP port to 3001
- mention new port in docs
- update Cursor MCP config

## Testing
- `pnpm run test --filter cli-v3` *(fails: fetch to registry.npmjs.org blocked)*

------
https://chatgpt.com/codex/tasks/task_b_6866cb5386948320848dd76928cc1a4e